### PR TITLE
Feat: 이미지 있는 게시글 업로드 및 이미지 있는 게시글 조회 기능 추가

### DIFF
--- a/src/main/java/org/example/springbootdeveloper/config/WebMvcConfig.java
+++ b/src/main/java/org/example/springbootdeveloper/config/WebMvcConfig.java
@@ -10,7 +10,7 @@ public class WebMvcConfig implements WebMvcConfigurer {
     @Override
     public void addResourceHandlers(ResourceHandlerRegistry registry) {
         // 웹 브라우저 URL '/img/**' 요청을 로컬 'uploads' 폴더로 매핑
-        registry.addResourceHandler("/img/**")
+        registry.addResourceHandler("/upload/**")
                 .addResourceLocations("file:///" + System.getProperty("user.dir") + "/imgfiles/");
     }
 }

--- a/src/main/java/org/example/springbootdeveloper/config/WebMvcConfig.java
+++ b/src/main/java/org/example/springbootdeveloper/config/WebMvcConfig.java
@@ -1,0 +1,16 @@
+package org.example.springbootdeveloper.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebMvcConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addResourceHandlers(ResourceHandlerRegistry registry) {
+        // 웹 브라우저 URL '/img/**' 요청을 로컬 'uploads' 폴더로 매핑
+        registry.addResourceHandler("/img/**")
+                .addResourceLocations("file:///" + System.getProperty("user.dir") + "/imgfiles/");
+    }
+}

--- a/src/main/java/org/example/springbootdeveloper/controller/BlogApiController.java
+++ b/src/main/java/org/example/springbootdeveloper/controller/BlogApiController.java
@@ -10,6 +10,7 @@ import org.example.springbootdeveloper.service.BlogService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.security.Principal;
 import java.util.List;
@@ -20,8 +21,11 @@ public class BlogApiController {
     private final BlogService blogService;
 
     @PostMapping("/api/articles") //HTTP 메서드가 POST일때 전달받은 URL과 동일하면 메서드 매핑
-    public ResponseEntity<Article> addArticle(@RequestBody AddArticleRequest request, Principal principal) {
-        Article savedArticle = blogService.save(request, principal.getName());
+    public ResponseEntity<Article> addArticle(
+            @RequestPart("request") AddArticleRequest request,
+            Principal principal,
+            @RequestPart("images") List<MultipartFile> images) {
+        Article savedArticle = blogService.save(request, principal.getName(), images);
 
         //요청한 자원이 성공적으로 생성되었으면 저장된 블로그 글 정보를 응답 객체에 담아 전송
         return ResponseEntity.status(HttpStatus.CREATED)

--- a/src/main/java/org/example/springbootdeveloper/controller/BlogApiController.java
+++ b/src/main/java/org/example/springbootdeveloper/controller/BlogApiController.java
@@ -24,7 +24,7 @@ public class BlogApiController {
     public ResponseEntity<Article> addArticle(
             @RequestPart("request") AddArticleRequest request,
             Principal principal,
-            @RequestPart("images") List<MultipartFile> images) {
+            @RequestPart(value = "images", required = false) List<MultipartFile> images) {
         Article savedArticle = blogService.save(request, principal.getName(), images);
 
         //요청한 자원이 성공적으로 생성되었으면 저장된 블로그 글 정보를 응답 객체에 담아 전송

--- a/src/main/java/org/example/springbootdeveloper/domain/Article.java
+++ b/src/main/java/org/example/springbootdeveloper/domain/Article.java
@@ -10,6 +10,8 @@ import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 
 @EntityListeners(AuditingEntityListener.class)
@@ -45,13 +47,19 @@ public class Article {
     @Column(name="like_count",nullable = false) 
     private Integer likeCount=0;  //좋아요 개수 0으로 초기화
 
+    // mappedBy="article": Image 클래스의 'article' 필드가 관계의 주인임을 표시
+    // CascadeType.ALL: 게시글 지우면 이미지도 삭제
+    // orphanRemoval=true: 리스트에서 이미지를 제거하면 DB에서도 삭제
+    @OneToMany(mappedBy = "article", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Image> images = new ArrayList<>(); // NullPointerException 방지 초기화
+
     @Builder //빌더 패턴으로 객체 생성
     public Article(String author,String title, String content) {
         this.author = author;
         this.title = title;
         this.content = content;
         this.likeCount=0;
-
+        //image list는 위에서 초기화 했으므로 추가 안해도 괜찮음
     }
 
     public void update(String title, String content) {
@@ -70,5 +78,8 @@ public class Article {
 
         this.likeCount++;
     }
-
+    // 이미지를 추가할 때, 양방향 관계를 안전하게 맺어주는 메서드
+    public void addImage(Image image) {
+        this.images.add(image);
+    }
 }

--- a/src/main/java/org/example/springbootdeveloper/domain/Image.java
+++ b/src/main/java/org/example/springbootdeveloper/domain/Image.java
@@ -1,0 +1,49 @@
+package org.example.springbootdeveloper.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
+
+@Table(name = "images")
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+
+public class Image {
+
+    @Id //image_id(PK)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "image_id", updatable = false)
+    private Long id;
+
+    @Column(name = "image_url", nullable = false)
+    private String url;
+
+    @Column(name = "original_file_name", nullable = false)
+    private String originalFileName;
+
+    @Column(name = "upload_order", nullable = false)
+    private Integer uploadOrder;
+
+    //Article에 1:n
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "article_id", nullable = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)  //게시물 삭제 시 사용된 img도 같이 삭제
+    private Article article;    //FK
+
+    @Builder
+    public Image(Article article, String url, String originalFileName, Integer uploadOrder) {
+        this.article = article;
+        this.url = url;
+        this.originalFileName = originalFileName;
+        this.uploadOrder = uploadOrder;
+    }
+
+    public void updateUploadOrder(Integer uploadOrder) {    //upload 이미지 수정 시 순서 변경
+        this.uploadOrder = uploadOrder;
+    }
+}

--- a/src/main/java/org/example/springbootdeveloper/dto/ArticleViewResponse.java
+++ b/src/main/java/org/example/springbootdeveloper/dto/ArticleViewResponse.java
@@ -3,8 +3,11 @@ package org.example.springbootdeveloper.dto;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.example.springbootdeveloper.domain.Article;
+import org.example.springbootdeveloper.domain.Image;
 
 import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @NoArgsConstructor
 @Getter
@@ -16,6 +19,7 @@ public class ArticleViewResponse {
     private LocalDateTime createdAt;
     private String author;
     private Integer likeCount;
+    private List<String> imageUrls;
 
     public ArticleViewResponse(Article article) {
         this.id = article.getId();
@@ -24,5 +28,8 @@ public class ArticleViewResponse {
         this.createdAt=article.getCreateAt();
         this.author=article.getAuthor();
         this.likeCount=article.getLikeCount();
+        this.imageUrls = article.getImages().stream()
+                .map(Image::getUrl)
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/org/example/springbootdeveloper/repository/ImageRepository.java
+++ b/src/main/java/org/example/springbootdeveloper/repository/ImageRepository.java
@@ -1,0 +1,7 @@
+package org.example.springbootdeveloper.repository;
+
+import org.example.springbootdeveloper.domain.Image;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ImageRepository extends JpaRepository<Image, Long> {
+}

--- a/src/main/java/org/example/springbootdeveloper/service/ImageFileService.java
+++ b/src/main/java/org/example/springbootdeveloper/service/ImageFileService.java
@@ -42,7 +42,7 @@ public class ImageFileService {
 
             // 저장된 경로(또는 파일명) 반환
             // 배포를 위해 AWS S3 사용 시 "https://s3..." URL을 반환하도록 수정 예정
-            return filePath;
+            return "/img/" + savedFileName;
 
         } catch (IOException e) {
             // 파일 저장 중 에러 발생 시 예외 처리

--- a/src/main/java/org/example/springbootdeveloper/service/ImageFileService.java
+++ b/src/main/java/org/example/springbootdeveloper/service/ImageFileService.java
@@ -1,0 +1,53 @@
+package org.example.springbootdeveloper.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.UUID;
+
+@Service
+public class ImageFileService {
+
+    // 프로젝트 루트 경로에 'imgfiles' 폴더를 생성해서 저장
+    // System.getProperty("user.dir")은 현재 프로젝트의 절대 경로를 반환
+    private final String fileDir = System.getProperty("user.dir") + "/imgfiles/";
+
+    //MultipartFile -> spring에서 file upload를 처리
+    public String upload(MultipartFile file) {
+        if (file.isEmpty()) {
+            return null; // 파일이 없으면 null 반환
+        }
+
+        try {
+            // 저장할 폴더가 없으면 생성
+            File directory = new File(fileDir);
+            if (!directory.exists()) {
+                directory.mkdirs();
+            }
+
+            // 원본 파일 이름 가져오기
+            String originalFilename = file.getOriginalFilename();
+
+            // 파일 이름 중복 방지를 위한 UUID(난수) 생성 (ex: uuid_originalName.jpg)
+            // 다른 파일과 중복되어 파일 덮어쓰기 되는 것을 방지
+            String savedFileName = UUID.randomUUID() + "_" + originalFilename;
+
+            // 파일 저장 경로 설정
+            String filePath = fileDir + savedFileName;
+
+            // 실제로 로컬에 파일 저장
+            file.transferTo(new File(filePath));
+
+            // 저장된 경로(또는 파일명) 반환
+            // 배포를 위해 AWS S3 사용 시 "https://s3..." URL을 반환하도록 수정 예정
+            return filePath;
+
+        } catch (IOException e) {
+            // 파일 저장 중 에러 발생 시 예외 처리
+            e.printStackTrace();
+            return null;
+        }
+    }
+}

--- a/src/main/java/org/example/springbootdeveloper/service/ImageFileService.java
+++ b/src/main/java/org/example/springbootdeveloper/service/ImageFileService.java
@@ -42,7 +42,7 @@ public class ImageFileService {
 
             // 저장된 경로(또는 파일명) 반환
             // 배포를 위해 AWS S3 사용 시 "https://s3..." URL을 반환하도록 수정 예정
-            return "/img/" + savedFileName;
+            return "/upload/" + savedFileName;
 
         } catch (IOException e) {
             // 파일 저장 중 에러 발생 시 예외 처리

--- a/src/main/resources/templates/article.html
+++ b/src/main/resources/templates/article.html
@@ -32,6 +32,11 @@
                 </header>
                 <section class="mb-5">
                     <p class="fs-5 mb-4" th:text="${article.content}"></p>
+                    <!--image 표시-->
+                    <div th:each="imageUrl : ${article.imageUrls}" class="mb-3">
+                        <!-- th:src에 이미지 URL 변수 할당 -->
+                        <img th:src="${imageUrl}" class="img-fluid" alt="게시글 이미지">
+                    </div>
                 </section>
 
 

--- a/src/main/resources/templates/newArticle.html
+++ b/src/main/resources/templates/newArticle.html
@@ -15,16 +15,22 @@
     <div class="row">
         <div class="col-lg-8">
             <article>
-                <input type="hidden" id="article-id" th:value="${article.id}">
+                <form id="article-form" enctype="multipart/form-data">
+                    <input type="hidden" id="article-id" th:value="${article.id}">
 
-                <header class="mb-4">
-                    <input type="text" class="form-control" placeholder="제목" id="title" th:value="${article.title}">
-                </header>
-                <section class="mb-5">
-                    <textarea class="form-control h-25" rows="10" placeholder="내용" id="content" th:text="${article.content}"></textarea>
-                </section>
-                <button th:if="${article.id} != null" type="button" id="modify-btn" class="btn btn-primary btn-sm">수정</button>
-                <button th:if="${article.id} == null" type="button" id="create-btn" class="btn btn-primary btn-sm">등록</button>
+                    <header class="mb-4">
+                        <input type="text" class="form-control" placeholder="제목" id="title" th:value="${article.title}">
+                    </header>
+                    <section class="mb-5">
+                        <textarea class="form-control h-25" rows="10" placeholder="내용" id="content" th:text="${article.content}"></textarea>
+                    </section>
+                    <div class="mb-6">
+                        <label for="files">이미지 업로드</label>
+                        <input type="file" id="files" class="form control" multiple>
+                    </div>
+                    <button th:if="${article.id} != null" type="button" id="modify-btn" class="btn btn-primary btn-sm">수정</button>
+                    <button th:if="${article.id} == null" type="button" id="create-btn" class="btn btn-primary btn-sm">등록</button>
+                </form>
             </article>
         </div>
     </div>


### PR DESCRIPTION
# 이미지 조회 및 업로드 기능

### 1. DB, Entity 설계
    1. Image Entity 생성 (Image.java)
    2. Article Entity 수정 (Article.java)
    3. ImageRepository 생성
### 2. 백엔드 구현 (Service, Controller)
    1. 이미지 파일 경로 지정 및 저장 (ImageFileService.java)
        
        → 현재는 local 주소에 저장하는 방식이지만 추후 배포 시 S3로 옮길 수 있음
        
    2. BlogService 수정 (BlogService.java)
        
        → save method가 DTO와 Image List를 함께 받도록
        
    3. BlogApiController 수정 (BlogApiController.java)
        
        → MultiPart/form-data 방식으로 DTO와 File을 동시에 받을 수 있도록 수정 (@RequestPart(~~)형식)
        
### 3. 프론트엔드 수정 (View, Js)
    1. 글 작성 페이지에 이미지 추가할 수 있는 tag 추가 (newArticle.html)
    2. 글 조회 페이지 수정 (article.html, ArticleViewResponse.java)
        
        → ArticleViewResponse DTO에 imgUrl list 포함
        
        → article.html에서 이미지 리스트를 반복하며 이미지를 보여줌